### PR TITLE
Replicate legacy behaviour

### DIFF
--- a/MaidClass.lua
+++ b/MaidClass.lua
@@ -17,6 +17,13 @@ function Maid:GiveTask(Task: MaidTask)
 	table.insert(self._Tasks, Task)
 end
 
+function Maid:LinkToInstance(Object: Instance)
+	self:GiveTask(Object)
+	self:GiveTask(Object.Destroying:Connect(function()
+		self:DoCleaning()
+	end))
+end
+
 function Maid:DoCleaning()
 	local Tasks = self._Tasks
 	self._Tasks = {}


### PR DESCRIPTION
Adds LinkToInstance replicating full legacy behaviour and fixes #1.

Will need to **wait until `Destroying` event is enabled** in the engine.